### PR TITLE
Fix for Theme Overriding Issue

### DIFF
--- a/extension/public/content.js
+++ b/extension/public/content.js
@@ -1,7 +1,19 @@
 // content.js
 
+// List of all possible themes
+const themes = ['defaultTheme', 'theme-red', 'theme-green', 'theme-navy-blue','theme-black','theme-teal',
+'theme-ocean','theme-purple','theme-pink','theme-orange', 'theme-yellow','theme-grey'];
+
+
+// Function to remove all theme classes
+function removeThemes() {
+    themes.forEach(theme => document.body.classList.remove(theme));
+}
+
+// Updated applyTheme function
 function applyTheme(theme) {
     if (theme) {
+        removeThemes();
         document.body.classList.add(`theme-${theme}`);
     } else {
         console.log("Error in loading theme");
@@ -20,12 +32,11 @@ chrome.storage.local.get(['currentTheme'], function(result) {
     applyTheme(result.currentTheme);
 });
 
-// Function to update extension state
+// Updated function to update extension state
 function updateExtensionState(isEnabled) {
     if (!isEnabled) {
         // Clear any applied theme when the extension is disabled
-        document.body.classList.remove('defaultTheme', 'theme-red', 'theme-green', 'theme-navy-blue','theme-black','theme-teal',
-        'theme-ocean','theme-purple','theme-pink','theme-orange', 'theme-yellow','theme-grey');
+        removeThemes();
     }
 }
 
@@ -38,10 +49,3 @@ chrome.runtime.onMessage.addListener(function(request, sender, sendResponse) {
 
 // Assume the initial extension state is enabled
 updateExtensionState(true);
-
-
-
-
-
-
-


### PR DESCRIPTION
## Description

This PR refactors the theme application logic in `content.js` to fix the issue #48 where selecting a new theme would not remove the previous theme, causing CSS rules to override each other. 

## Changes

- Added a list of all possible themes.
- Created a function `removeThemes` to remove all theme classes from the body element.
- Updated the `applyTheme` function to call `removeThemes` before adding the new theme class.
- Updated the `updateExtensionState` function to call `removeThemes` when the extension is disabled.

## Testing

To test the changes, follow these steps:

1. Load the extension in Chrome.
2. Open the popup and select a theme.
3. Verify that the selected theme is applied correctly.
4. Select a different theme and verify that the new theme is applied correctly and the previous theme is removed.

https://github.com/wellingtonmwadali/ALX_MultiTone-Magic/assets/24565896/685466dd-99f6-42b6-af9d-c1043d545758

## Impact

These changes ensure that only the selected theme's CSS rules are applied, improving the extension's usability and user experience.




Fixes #48